### PR TITLE
Feat/sync

### DIFF
--- a/cli/tldr/sync.go
+++ b/cli/tldr/sync.go
@@ -46,5 +46,5 @@ func (s *syncCmd) simpleSync() error {
 }
 
 func (s *syncCmd) multiSync() error {
-	return nil
+	return fmt.Errorf("Sync with storage rotation not yet implemented")
 }

--- a/cli/tldr/sync.go
+++ b/cli/tldr/sync.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/nikcorg/tldr-cli/config/rotation"
 	"github.com/nikcorg/tldr-cli/storage"
 	"github.com/nikcorg/tldr-cli/sync"
@@ -20,9 +22,19 @@ func (s *syncCmd) ParseArgs(subcommand string, args ...string) error {
 	return nil
 }
 
-func (s *syncCmd) Init() {}
+func (s *syncCmd) Help(subcommand string, args ...string) {
+	fmt.Print(strings.Replace(heredoc.Doc(`
+		Sync the tldr log with a remote 
 
-func (s *syncCmd) Help(subcommand string, args ...string) {}
+		__BINARY_NAME__ sync
+
+		Sync runs an external command and provides to it as arguments:
+		1. the directory containing the tldr log files
+		2. the log file to sync
+
+		Currently only syncing a single log file is implemented
+	`), "__BINARY_NAME__", binaryName, -1))
+}
 
 func (s *syncCmd) Execute(subcommand string, args ...string) error {
 	if runtimeConfig.Sync.Exec == "" && runtimeConfig.Sync.Remote != "" {

--- a/cli/tldr/sync.go
+++ b/cli/tldr/sync.go
@@ -10,6 +10,8 @@ import (
 
 type syncCmd struct{}
 
+func (s *syncCmd) Init() {}
+
 func (s *syncCmd) Verbs() []string {
 	return []string{"sync"}
 }

--- a/cli/tldr/sync.go
+++ b/cli/tldr/sync.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -60,5 +61,5 @@ func (s *syncCmd) simpleSync() error {
 }
 
 func (s *syncCmd) multiSync() error {
-	return fmt.Errorf("Sync with storage rotation not yet implemented")
+	return errors.New("sync with storage rotation not yet implemented")
 }

--- a/sync/command.go
+++ b/sync/command.go
@@ -1,21 +1,37 @@
 package sync
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
 	"syscall"
 
 	"github.com/nikcorg/tldr-cli/storage"
+	log "github.com/sirupsen/logrus"
+)
+
+// Known error outcomes
+var (
+	errSyncCommandNotConfigured = errors.New("no sync command is configured")
 )
 
 // WithCommand executes an external program to sync the local with a remote
 func (s *Sync) WithCommand(sources []*storage.Source) error {
-	var args []string = []string{s.config.Storage.Path}
+	if s.config.Sync.Exec == "" {
+		return errSyncCommandNotConfigured
+	}
+
+	var args = []string{path.Base(s.config.Sync.Exec), s.config.Storage.Path}
 
 	for _, source := range sources {
 		args = append(args, source.SourceFile)
 	}
 
-	if err := syscall.Exec(s.config.Sync.Exec, args, []string{}); err != nil {
-		return err
+	log.Debugf("running %s with args %v", s.config.Sync.Exec, args)
+
+	if err := syscall.Exec(s.config.Sync.Exec, args, os.Environ()); err != nil {
+		return fmt.Errorf("running sync command failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
- [x] Simple sync (external command, single log file)
- [ ] Simple multi-sync (external command, multiple log files)
- [ ] Smart sync: only run when logs are unsynced
- [ ] Auto-sync (run: before and|or after every add, before first add of the day, other option?)

Closes https://github.com/nikcorg/tldr-cli/issues/4