### PR TITLE
fix: maintain URL case

### DIFF
--- a/cli/tldr/add.go
+++ b/cli/tldr/add.go
@@ -180,7 +180,7 @@ func (c *addCmd) addEntry(source *storage.Source) error {
 	}
 
 	var newEntry = &storage.Entry{
-		URL:         strings.ToLower(res.URL),
+		URL:         res.URL,
 		Title:       c.title.Val(),
 		Unread:      c.unread.ValOrDefault(true),
 		RelatedURLs: c.relatedURLs,

--- a/input/entry/entry.go
+++ b/input/entry/entry.go
@@ -100,12 +100,12 @@ func edit(newEntry *storage.Entry, ctx *EditContext, mode string) error {
 		case sourceURL:
 			fmt.Printf("Enter source: ")
 			selection, _ = reader.ReadString('\n')
-			newEntry.SourceURL = strings.ToLower(strings.TrimSpace(selection))
+			newEntry.SourceURL = strings.TrimSpace(selection)
 
 		case relatedURL:
 			fmt.Printf("Enter related: ")
 			selection, _ = reader.ReadString('\n')
-			newEntry.RelatedURLs = append(newEntry.RelatedURLs, strings.ToLower(strings.TrimSpace(selection)))
+			newEntry.RelatedURLs = append(newEntry.RelatedURLs, strings.TrimSpace(selection))
 
 		case quit:
 			fmt.Println("Ok, quitting without saving.")


### PR DESCRIPTION
Lowercasing URLs while aesthetically pleasing, can invalidate a URL. 

E.g. https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values

While the document is (in this case) found also with the lowercased variant, the anchor is broken.